### PR TITLE
Redesign landing hero: left-aligned layout

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,7 +1,8 @@
 {
   "landingSection": {
     "softwareDev": "{symbol} Software-dev",
-    "greeting": "Hi, I'm <span>Rutger</span> from the Netherlands"
+    "greeting": "Hi, I'm <span>Rutger</span> from the Netherlands",
+    "subtitle": "Software-development student building web things with Next.js, TypeScript & a self-hosted Kubernetes pipeline."
   },
   "about": {
     "title": "Who am I?",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,7 +1,8 @@
 {
   "landingSection": {
     "softwareDev": "{symbol} Software-dev",
-    "greeting": "Hallo, ik ben <span>Rutger</span> uit Nederland"
+    "greeting": "Hallo, ik ben <span>Rutger</span> uit Nederland",
+    "subtitle": "Software-development student die webdingen bouwt met Next.js, TypeScript & een self-hosted Kubernetes-pipeline."
   },
   "about": {
     "title": "Wie ben ik?",

--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -62,6 +62,28 @@
   background: #000000;
 }
 
+/* Glow behind the landing headline accent word. */
+.accent-glow {
+  text-shadow:
+    0 0 28px rgba(255, 54, 90, 0.45),
+    0 0 60px rgba(255, 54, 90, 0.22);
+}
+
+/* Faint dot grid behind the landing hero, faded out from the top-left. */
+.landing-dotgrid {
+  background-image: radial-gradient(
+    rgba(255, 255, 255, 0.05) 1px,
+    transparent 1px
+  );
+  background-size: 34px 34px;
+  -webkit-mask-image: radial-gradient(
+    120% 120% at 12% 12%,
+    #000 30%,
+    transparent 75%
+  );
+  mask-image: radial-gradient(120% 120% at 12% 12%, #000 30%, transparent 75%);
+}
+
 .transition-stack {
   width: 100%;
   height: 200px;

--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -69,18 +69,18 @@
     0 0 60px rgba(255, 54, 90, 0.22);
 }
 
-/* Soft accent glow behind the hero. A radial gradient (not a blurred circle)
-   so it always fades to transparent and never shows a hard clipped edge. */
+/* Soft accent glow centered behind the headline. Single fade to transparent
+   (two stops) so there is never a perceptible ring/edge. */
 .landing-glow {
   background: radial-gradient(
-    45% 55% at 24% 30%,
-    rgba(255, 54, 90, 0.22) 0%,
-    rgba(255, 54, 90, 0.08) 38%,
+    52% 50% at 32% 48%,
+    rgba(255, 54, 90, 0.2) 0%,
     transparent 72%
   );
 }
 
-/* Faint dot grid behind the landing hero, faded out from the top-left. */
+/* Faint dot grid behind the hero, fading gradually around the same focal
+   point as the glow so it never shows a density boundary. */
 .landing-dotgrid {
   background-image: radial-gradient(
     rgba(255, 255, 255, 0.05) 1px,
@@ -88,11 +88,11 @@
   );
   background-size: 34px 34px;
   -webkit-mask-image: radial-gradient(
-    120% 120% at 12% 12%,
-    #000 30%,
-    transparent 75%
+    90% 90% at 32% 48%,
+    #000 0%,
+    transparent 80%
   );
-  mask-image: radial-gradient(120% 120% at 12% 12%, #000 30%, transparent 75%);
+  mask-image: radial-gradient(90% 90% at 32% 48%, #000 0%, transparent 80%);
 }
 
 .transition-stack {

--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -69,6 +69,17 @@
     0 0 60px rgba(255, 54, 90, 0.22);
 }
 
+/* Soft accent glow behind the hero. A radial gradient (not a blurred circle)
+   so it always fades to transparent and never shows a hard clipped edge. */
+.landing-glow {
+  background: radial-gradient(
+    45% 55% at 24% 30%,
+    rgba(255, 54, 90, 0.22) 0%,
+    rgba(255, 54, 90, 0.08) 38%,
+    transparent 72%
+  );
+}
+
 /* Faint dot grid behind the landing hero, faded out from the top-left. */
 .landing-dotgrid {
   background-image: radial-gradient(

--- a/src/components/LandingSection.tsx
+++ b/src/components/LandingSection.tsx
@@ -59,12 +59,12 @@ export default function LandingSection() {
         </h2>
         <h1
           className={
-            "accent-glow mt-6 max-w-[15ch] text-left text-6xl font-bold leading-[0.98] tracking-tight text-textPrimary sm:text-7xl lg:text-8xl"
+            "mt-6 max-w-[15ch] text-left text-6xl font-bold leading-[0.98] tracking-tight text-textPrimary sm:text-7xl lg:text-8xl"
           }
         >
           {t.rich("greeting", {
             span: (children) => (
-              <span className={"text-accent"}>{children}</span>
+              <span className={"accent-glow text-accent"}>{children}</span>
             ),
           })}
         </h1>

--- a/src/components/LandingSection.tsx
+++ b/src/components/LandingSection.tsx
@@ -5,6 +5,15 @@ import ScrollDownHint from "@/components/ScrollDownHint";
 import { useTranslations } from "next-intl";
 import { motion, useScroll, useTransform } from "framer-motion";
 
+const SKILLS = [
+  "TypeScript",
+  "Next.js",
+  "React",
+  "Tailwind CSS",
+  "Kubernetes",
+  "Terraform",
+];
+
 export default function LandingSection() {
   const t = useTranslations("landingSection");
 
@@ -15,23 +24,42 @@ export default function LandingSection() {
     offset: ["start start", "end start"],
   });
   const textY = useTransform(scrollYProgress, [0, 1], ["0%", "300%"]);
+  const glowOpacity = useTransform(scrollYProgress, [0, 1], [0.18, 0]);
 
   return (
     <section
       ref={ref}
       id={"home"}
-      className={"flex min-h-screen flex-col items-center justify-between"}
+      className={
+        "relative flex min-h-screen flex-col items-start justify-between overflow-hidden"
+      }
     >
+      {/* Dot grid + accent glow, anchored to the top-left behind the hero. */}
+      <div className={"pointer-events-none absolute inset-0 -z-10"}>
+        <div className={"landing-dotgrid absolute inset-0"} />
+        <motion.div
+          style={{ opacity: glowOpacity }}
+          className={
+            "absolute -left-[10%] -top-[10%] h-[55vh] w-[55vh] rounded-full bg-accent blur-[120px]"
+          }
+        />
+      </div>
+
       <div></div>
+
       <motion.div style={{ y: textY }} className={"max-w-full"}>
-        <h2 className={"text-center text-3xl text-textPrimary sm:text-4xl"}>
+        <h2
+          className={
+            "font-mono text-base tracking-[0.32em] text-accent sm:text-lg"
+          }
+        >
           {t.rich("softwareDev", {
             symbol: "</>",
           })}
         </h2>
         <h1
           className={
-            "mb-10 max-w-2xl text-center text-5xl font-bold text-textPrimary sm:text-6xl"
+            "accent-glow mt-6 max-w-[15ch] text-left text-6xl font-bold leading-[0.98] tracking-tight text-textPrimary sm:text-7xl lg:text-8xl"
           }
         >
           {t.rich("greeting", {
@@ -40,6 +68,24 @@ export default function LandingSection() {
             ),
           })}
         </h1>
+        <p className={"mt-6 max-w-[46ch] text-base text-textSecondary sm:text-lg"}>
+          {t("subtitle")}
+        </p>
+        <div className={"mt-9 flex flex-wrap gap-3"}>
+          {SKILLS.map((skill, index) => (
+            <span
+              key={skill}
+              className={
+                "rounded-full border px-4 py-2 text-sm " +
+                (index === 0
+                  ? "border-accent text-accent"
+                  : "border-white/10 text-textSecondary")
+              }
+            >
+              {skill}
+            </span>
+          ))}
+        </div>
       </motion.div>
 
       <ScrollDownHint />

--- a/src/components/LandingSection.tsx
+++ b/src/components/LandingSection.tsx
@@ -24,7 +24,7 @@ export default function LandingSection() {
     offset: ["start start", "end start"],
   });
   const textY = useTransform(scrollYProgress, [0, 1], ["0%", "300%"]);
-  const glowOpacity = useTransform(scrollYProgress, [0, 1], [0.18, 0]);
+  const glowOpacity = useTransform(scrollYProgress, [0, 1], [1, 0]);
 
   return (
     <section
@@ -39,9 +39,7 @@ export default function LandingSection() {
         <div className={"landing-dotgrid absolute inset-0"} />
         <motion.div
           style={{ opacity: glowOpacity }}
-          className={
-            "absolute -left-[10%] -top-[10%] h-[55vh] w-[55vh] rounded-full bg-accent blur-[120px]"
-          }
+          className={"landing-glow absolute inset-0"}
         />
       </div>
 


### PR DESCRIPTION
## What

Reworks the landing section into a **left-aligned** hero, keeping the existing accent color (`#FF365A`).

### Changes
- Mono `</> Software-dev` eyebrow above the headline
- Larger headline with an accent glow on the name
- New subtitle line (added `landingSection.subtitle` to `en`/`nl`)
- Skill pills row (TypeScript highlighted)
- Subtle dot-grid + accent glow backdrop, anchored top-left, fading on scroll

### Notes
- Color unchanged on purpose (variant D), layout switched from centered → left-aligned per request.
- Verified locally: `tsc --noEmit` clean, eslint clean, rendered desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)