### PR TITLE
fix: resolve lint warnings + fail CI on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/src/components/header/UnderlineScrollLink.tsx
+++ b/src/components/header/UnderlineScrollLink.tsx
@@ -35,10 +35,13 @@ export default function UnderlineScrollLink({
 
   useEffect(() => {
     window.addEventListener("scroll", handleLinkUnderline);
-    handleLinkUnderline();
+    // Defer the initial measurement out of the effect body (and to a frame
+    // where layout is settled) so it doesn't setState synchronously on mount.
+    const raf = requestAnimationFrame(handleLinkUnderline);
 
     return () => {
       window.removeEventListener("scroll", handleLinkUnderline);
+      cancelAnimationFrame(raf);
     };
   }, []);
 

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useCallback, useSyncExternalStore } from "react";
 
 export function usePersistedState(
   key: string,
@@ -6,18 +6,32 @@ export function usePersistedState(
 ): readonly [string, Dispatch<SetStateAction<string>>] {
   const storageKey = "persistedState." + key;
 
-  const [value, setValue] = useState(defaultValue);
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    window.addEventListener("storage", onStoreChange);
+    return () => window.removeEventListener("storage", onStoreChange);
+  }, []);
 
-  useEffect(() => {
-    const storedValue = localStorage.getItem(storageKey);
-    if (storedValue !== null) {
-      setValue(storedValue);
-    }
-  }, [storageKey]);
+  // Read localStorage as an external store: no setState-in-effect, and the
+  // server snapshot keeps SSR/hydration consistent.
+  const value = useSyncExternalStore(
+    subscribe,
+    () => localStorage.getItem(storageKey) ?? defaultValue,
+    () => defaultValue,
+  );
 
-  useEffect(() => {
-    localStorage.setItem(storageKey, value);
-  }, [storageKey, value]);
+  const setValue = useCallback<Dispatch<SetStateAction<string>>>(
+    (next) => {
+      const resolved =
+        typeof next === "function"
+          ? next(localStorage.getItem(storageKey) ?? defaultValue)
+          : next;
+      localStorage.setItem(storageKey, resolved);
+      // Notify subscribers in the current tab (the native `storage` event
+      // only fires in other tabs).
+      window.dispatchEvent(new StorageEvent("storage"));
+    },
+    [storageKey, defaultValue],
+  );
 
   return [value, setValue] as const;
 }


### PR DESCRIPTION
Follow-up to the Next 16 migration: resolves the two `react-hooks/set-state-in-effect` warnings and makes the lint job strict.

- **usePersistedState.ts**: now reads localStorage through `useSyncExternalStore` (with a server snapshot for SSR) instead of hydrating into state via an effect. (This hook is currently unused, so blast radius is nil.)
- **UnderlineScrollLink.tsx**: the initial scroll measurement is deferred with `requestAnimationFrame` so it no longer calls setState synchronously inside the effect body.
- **lint script**: now `eslint . --max-warnings 0` so any warning fails CI.

Verified locally: `bun run lint` (0 warnings) and `bun run typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)