### PR TITLE
Restore original landing background color (#121125)

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -55,7 +55,7 @@ export default async function RootLayout({
   const { locale } = await params;
   return (
     <html lang={locale}>
-      <body className={`${inter.className} bg-landing`}>
+      <body className={`${inter.className} bg-primary`}>
         <ReactQueryProvider>
           <NextIntlClientProvider>{children}</NextIntlClientProvider>
         </ReactQueryProvider>


### PR DESCRIPTION
## Wat
Zet de achtergrondkleur van de landing-sectie terug naar de **originele** kleur.

## Waarom
De body gebruikte sinds [#89](https://github.com/Rutger505-Org/rutgerpronk.com/pull/89) (okt 2025) `bg-landing` = `#000e28` (donker navy). Daarvóór was het altijd `bg-primary` = `#121125` (de originele kleur).

## Wijziging
- `src/app/[locale]/layout.tsx`: `bg-landing` → `bg-primary` op de `<body>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)