### PR TITLE
Restore original landing background color

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -55,7 +55,7 @@ export default async function RootLayout({
   const { locale } = await params;
   return (
     <html lang={locale}>
-      <body className={`${inter.className} bg-landing`}>
+      <body className={`${inter.className} bg-primary`}>
         <ReactQueryProvider>
           <NextIntlClientProvider>{children}</NextIntlClientProvider>
         </ReactQueryProvider>


### PR DESCRIPTION
De achtergrond van de landing-sectie was in #89 gewijzigd van `bg-primary` (#121125, het originele donkerpaars) naar `bg-landing` (#000e28, donkerblauw).

Deze PR zet de body terug naar `bg-primary`, de originele kleur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)